### PR TITLE
Fixed animations and refactored state to components

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 use crate::{menu::MenuPlugIn, player::PlayerPlugIn, setup::SetupPlugIn};
-use bevy::input::common_conditions::input_toggle_active;
-use bevy::prelude::*;
+use bevy::{input::common_conditions::input_toggle_active, prelude::*};
 use bevy_egui::EguiPlugin;
 use bevy_inspector_egui::quick::{StateInspectorPlugin, WorldInspectorPlugin};
 
@@ -12,23 +11,22 @@ mod setup;
 
 fn main() {
     let mut app = App::new();
+    app.register_type::<GameState>()
+        .register_type::<FacingDirection>()
+        .register_type::<EntityState>()
+        .register_type::<MovementSpeed>();
+
     app.add_plugins((
         DefaultPlugins.set(ImagePlugin::default_nearest()),
         EguiPlugin::default(),
         WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::AltLeft)),
         StateInspectorPlugin::<GameState>::default(),
-        StateInspectorPlugin::<FacingDirectionState>::default(),
-        StateInspectorPlugin::<MovementState>::default(),
         MenuPlugIn,
         PlayerPlugIn,
         SetupPlugIn,
     ));
 
-    app.register_type::<GameState>();
-
-    app.init_state::<GameState>()
-        .init_state::<FacingDirectionState>()
-        .init_state::<MovementState>();
+    app.init_state::<GameState>();
 
     app.run();
 }
@@ -42,9 +40,11 @@ pub enum GameState {
     Menu,
 }
 
-#[derive(States, Default, Clone, PartialEq, Eq, Hash, Debug, Reflect)]
-#[states(scoped_entities)]
-pub enum FacingDirectionState {
+#[derive(Component, Reflect)]
+pub struct MovementSpeed(f32);
+
+#[derive(Component, Default, Reflect, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum FacingDirection {
     #[default]
     Down,
     Up,
@@ -52,13 +52,10 @@ pub enum FacingDirectionState {
     Right,
 }
 
-#[derive(States, Default, Clone, PartialEq, Eq, Hash, Debug, Reflect)]
-#[states(scoped_entities)]
-pub enum MovementState {
+#[derive(Component, Default, Reflect, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[reflect(Component)]
+pub enum EntityState {
     #[default]
     Idle,
     Moving,
 }
-
-#[derive(Component, Reflect)]
-pub struct MovementSpeed(f32);

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,225 +1,148 @@
-use crate::FacingDirectionState;
-use crate::GameState;
-use crate::MovementSpeed;
-use crate::MovementState;
-use crate::setup::AnimationConfig;
-use crate::setup::GameAssets;
+use crate::{
+    EntityState, FacingDirection, GameState, MovementSpeed,
+    setup::{AnimationConfig, GameAssets},
+};
 use bevy::prelude::*;
 
 pub struct PlayerPlugIn;
 
 impl Plugin for PlayerPlugIn {
     fn build(&self, app: &mut App) {
-        app.register_type::<Player>()
-            .add_systems(Update, animate_player.run_if(in_state(GameState::Playing)));
+        app.register_type::<Player>().add_systems(
+            Update,
+            (move_player, animate_player).run_if(in_state(GameState::Playing)),
+        );
     }
 }
 
 #[derive(Component, Reflect)]
 #[require(MovementSpeed(500.))]
 #[require(StateScoped::<GameState>(GameState::Playing))]
+#[require(FacingDirection)]
+#[require(EntityState)]
 pub struct Player;
 
+#[derive(Component, Reflect)]
+pub struct PlayerAnimationConfig {
+    pub idle_right: UVec2,
+    pub idle_up: UVec2,
+    pub idle_down: UVec2,
+    pub idle_left: UVec2,
+
+    pub walk_right: UVec2,
+    pub walk_up: UVec2,
+    pub walk_down: UVec2,
+    pub walk_left: UVec2,
+}
+
+fn move_player(
+    mut player_q: Query<(
+        &mut Transform,
+        &MovementSpeed,
+        &mut FacingDirection,
+        &mut EntityState,
+    )>,
+    key: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+) {
+    let Ok((mut tf, speed, mut facing, mut state)) = player_q.single_mut() else {
+        return;
+    };
+
+    let mut dir = Vec2::ZERO;
+
+    if key.pressed(KeyCode::KeyW) {
+        dir.y += 1.0;
+    }
+    if key.pressed(KeyCode::KeyS) {
+        dir.y -= 1.0;
+    }
+    if key.pressed(KeyCode::KeyA) {
+        dir.x -= 1.0;
+    }
+    if key.pressed(KeyCode::KeyD) {
+        dir.x += 1.0;
+    }
+
+    if dir == Vec2::ZERO {
+        *state = EntityState::Idle;
+        return;
+    }
+
+    let displacement = dir.normalize() * speed.0 * time.delta_secs();
+    tf.translation.x += displacement.x;
+    tf.translation.y += displacement.y;
+
+    *state = EntityState::Moving;
+
+    *facing = if dir.x.abs() > dir.y.abs() {
+        if dir.x > 0.0 {
+            FacingDirection::Right
+        } else {
+            FacingDirection::Left
+        }
+    } else if dir.y > 0.0 {
+        FacingDirection::Up
+    } else {
+        FacingDirection::Down
+    };
+}
+
 fn animate_player(
-    mut query: Query<
+    mut player_q: Query<
         (
-            &mut Transform,
-            &MovementSpeed,
-            &mut Sprite,
+            &PlayerAnimationConfig,
+            &FacingDirection,
+            &EntityState,
             &mut AnimationConfig,
+            &mut Sprite,
         ),
         With<Player>,
     >,
-    movement_state: Res<State<MovementState>>,
-    facing_state: Res<State<FacingDirectionState>>,
-    game_assets: Res<GameAssets>,
-    key: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
-    mut next_facing_state: ResMut<NextState<FacingDirectionState>>,
-    mut next_movement_state: ResMut<NextState<MovementState>>,
+    game_assets: Res<GameAssets>,
 ) {
-    for (mut position, movement_speed, mut sprite, mut animation) in &mut query {
-        if key.just_pressed(KeyCode::KeyW) {
-            next_facing_state.set(FacingDirectionState::Up);
-            next_movement_state.set(MovementState::Moving);
+    for (clips, facing, state, mut anim, mut sprite) in player_q.iter_mut() {
+        let range = match (*state, *facing) {
+            (EntityState::Idle, FacingDirection::Down) => clips.idle_down,
+            (EntityState::Idle, FacingDirection::Up) => clips.idle_up,
+            (EntityState::Idle, FacingDirection::Left) => clips.idle_left,
+            (EntityState::Idle, FacingDirection::Right) => clips.idle_right,
 
-            set_sprite_and_animation(
-                &game_assets,
-                &movement_state,
-                &mut sprite,
-                &mut animation,
-                6,
-                11,
-                10,
-            );
-        }
-        if key.pressed(KeyCode::KeyW) {
-            position.translation.y += movement_speed.0 * time.delta_secs();
-        }
-
-        if key.just_pressed(KeyCode::KeyA) {
-            next_facing_state.set(FacingDirectionState::Left);
-            next_movement_state.set(MovementState::Moving);
-
-            *sprite = Sprite {
-                image: game_assets.player_walk.clone(),
-                texture_atlas: Some(TextureAtlas {
-                    index: 12,
-                    layout: game_assets.player_walk_layout.clone(),
-                }),
-                ..default()
-            };
-
-            *animation = AnimationConfig::new(12, 17, 10);
-        }
-        if key.pressed(KeyCode::KeyA) {
-            position.translation.x -= movement_speed.0 * time.delta_secs();
-        }
-
-        if key.just_pressed(KeyCode::KeyS) {
-            next_facing_state.set(FacingDirectionState::Down);
-            next_movement_state.set(MovementState::Moving);
-
-            *sprite = Sprite {
-                image: game_assets.player_walk.clone(),
-                texture_atlas: Some(TextureAtlas {
-                    index: 0,
-                    layout: game_assets.player_walk_layout.clone(),
-                }),
-                ..default()
-            };
-
-            *animation = AnimationConfig::new(0, 5, 10);
-        }
-        if key.pressed(KeyCode::KeyS) {
-            position.translation.y -= movement_speed.0 * time.delta_secs();
-        }
-
-        if key.just_pressed(KeyCode::KeyD) {
-            next_facing_state.set(FacingDirectionState::Right);
-            next_movement_state.set(MovementState::Moving);
-
-            *sprite = Sprite {
-                image: game_assets.player_walk.clone(),
-                texture_atlas: Some(TextureAtlas {
-                    index: 18,
-                    layout: game_assets.player_walk_layout.clone(),
-                }),
-                ..default()
-            };
-
-            *animation = AnimationConfig::new(18, 23, 10);
-        }
-        if key.pressed(KeyCode::KeyD) {
-            position.translation.x += movement_speed.0 * time.delta_secs();
-        }
-
-        if !key.any_pressed([KeyCode::KeyW, KeyCode::KeyA, KeyCode::KeyS, KeyCode::KeyD])
-            && *movement_state == MovementState::Moving
-        {
-            next_movement_state.set(MovementState::Idle);
-
-            if *facing_state == FacingDirectionState::Up {
-                *sprite = Sprite {
-                    image: game_assets.player_idle.clone(),
-                    texture_atlas: Some(TextureAtlas {
-                        index: 4,
-                        layout: game_assets.player_idle_layout.clone(),
-                    }),
-                    ..default()
-                };
-
-                *animation = AnimationConfig::new(4, 7, 10);
-            }
-
-            if *facing_state == FacingDirectionState::Up {
-                *sprite = Sprite {
-                    image: game_assets.player_idle.clone(),
-                    texture_atlas: Some(TextureAtlas {
-                        index: 4,
-                        layout: game_assets.player_idle_layout.clone(),
-                    }),
-                    ..default()
-                };
-
-                *animation = AnimationConfig::new(4, 7, 10);
-            }
-
-            if *facing_state == FacingDirectionState::Left {
-                *sprite = Sprite {
-                    image: game_assets.player_idle.clone(),
-                    texture_atlas: Some(TextureAtlas {
-                        index: 8,
-                        layout: game_assets.player_idle_layout.clone(),
-                    }),
-                    ..default()
-                };
-
-                *animation = AnimationConfig::new(8, 11, 10);
-            }
-
-            if *facing_state == FacingDirectionState::Down {
-                *sprite = Sprite {
-                    image: game_assets.player_idle.clone(),
-                    texture_atlas: Some(TextureAtlas {
-                        index: 0,
-                        layout: game_assets.player_idle_layout.clone(),
-                    }),
-                    ..default()
-                };
-
-                *animation = AnimationConfig::new(0, 3, 10);
-            }
-
-            if *facing_state == FacingDirectionState::Right {
-                *sprite = Sprite {
-                    image: game_assets.player_idle.clone(),
-                    texture_atlas: Some(TextureAtlas {
-                        index: 12,
-                        layout: game_assets.player_idle_layout.clone(),
-                    }),
-                    ..default()
-                };
-
-                *animation = AnimationConfig::new(12, 15, 10);
-            }
-        };
-    }
-}
-
-fn set_sprite_and_animation(
-    game_assets: &Res<GameAssets>,
-    movement_state: &Res<State<MovementState>>,
-    sprite: &mut Sprite,
-    animation: &mut AnimationConfig,
-    first_animation_index: usize,
-    last_animation_index: usize,
-    animation_fps: u8,
-) {
-    if **movement_state == MovementState::Idle {
-        *sprite = Sprite {
-            image: game_assets.player_idle.clone(),
-            texture_atlas: Some(TextureAtlas {
-                index: first_animation_index,
-                layout: game_assets.player_idle_layout.clone(),
-            }),
-            ..default()
+            (EntityState::Moving, FacingDirection::Down) => clips.walk_down,
+            (EntityState::Moving, FacingDirection::Up) => clips.walk_up,
+            (EntityState::Moving, FacingDirection::Left) => clips.walk_left,
+            (EntityState::Moving, FacingDirection::Right) => clips.walk_right,
         };
 
-        *animation =
-            AnimationConfig::new(first_animation_index, last_animation_index, animation_fps);
-    } else if **movement_state == MovementState::Moving {
-        // It could just be "else", I put this in case MovementState includes something else in the future
-        *sprite = Sprite {
-            image: game_assets.player_walk.clone(),
-            texture_atlas: Some(TextureAtlas {
-                index: first_animation_index,
-                layout: game_assets.player_walk_layout.clone(),
-            }),
-            ..default()
-        };
+        let desired_first = range.x as usize;
+        let desired_last = range.y as usize;
 
-        *animation =
-            AnimationConfig::new(first_animation_index, last_animation_index, animation_fps);
+        let (desired_image, desired_layout) = game_assets.sheet_for_state(*state);
+
+        let must_swap_sheet = sprite.image != desired_image
+            || anim.first_sprite_index != desired_first
+            || anim.last_sprite_index != desired_last;
+
+        if must_swap_sheet {
+            *sprite = Sprite {
+                image: desired_image,
+                texture_atlas: Some(TextureAtlas {
+                    index: desired_first,
+                    layout: desired_layout,
+                }),
+                ..Default::default()
+            };
+            *anim = AnimationConfig::new(desired_first, desired_last, 10);
+        }
+
+        if anim.frame_timer.tick(time.delta()).just_finished() {
+            if let Some(atlas) = sprite.texture_atlas.as_mut() {
+                atlas.index += 1;
+                if atlas.index > anim.last_sprite_index {
+                    atlas.index = anim.first_sprite_index;
+                }
+            }
+        }
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -10,7 +10,9 @@ impl Plugin for PlayerPlugIn {
     fn build(&self, app: &mut App) {
         app.register_type::<Player>().add_systems(
             Update,
-            (move_player, animate_player).run_if(in_state(GameState::Playing)),
+            (move_player, animate_player)
+                .chain()
+                .run_if(in_state(GameState::Playing)),
         );
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use crate::{GameState, player::Player};
+use crate::{
+    EntityState, GameState,
+    player::{Player, PlayerAnimationConfig},
+};
 use bevy::prelude::*;
 use bevy_inspector_egui::quick::ResourceInspectorPlugin;
 
@@ -13,10 +16,7 @@ impl Plugin for SetupPlugIn {
         app.register_type::<AnimationConfig>();
 
         app.add_systems(Startup, (spawn_camera, load_assets))
-            .add_systems(
-                Update,
-                (update_camera, execute_animations).run_if(in_state(GameState::Playing)),
-            )
+            .add_systems(Update, (update_camera).run_if(in_state(GameState::Playing)))
             .add_systems(OnEnter(GameState::Playing), spawn_entities);
     }
 }
@@ -30,12 +30,24 @@ pub struct GameAssets {
     tree: Handle<Image>,
 }
 
+impl GameAssets {
+    pub fn sheet_for_state(
+        &self,
+        state: EntityState,
+    ) -> (Handle<Image>, Handle<TextureAtlasLayout>) {
+        match state {
+            EntityState::Idle => (self.player_idle.clone(), self.player_idle_layout.clone()),
+            EntityState::Moving => (self.player_walk.clone(), self.player_walk_layout.clone()),
+        }
+    }
+}
+
 #[derive(Component, Reflect)]
 pub struct AnimationConfig {
-    first_sprite_index: usize,
-    last_sprite_index: usize,
-    fps: u8,
-    frame_timer: Timer,
+    pub first_sprite_index: usize,
+    pub last_sprite_index: usize,
+    pub fps: u8,
+    pub frame_timer: Timer,
 }
 
 impl AnimationConfig {
@@ -116,6 +128,17 @@ fn spawn_entities(mut commands: Commands, game_assets: Res<GameAssets>) {
         Transform::default().with_scale(Vec3::splat(5.0)),
         Name::new("Player"),
         AnimationConfig::new(0, 3, 10),
+        PlayerAnimationConfig {
+            idle_down: UVec2::new(0, 3),
+            idle_up: UVec2::new(4, 7),
+            idle_left: UVec2::new(8, 11),
+            idle_right: UVec2::new(12, 15),
+
+            walk_down: UVec2::new(0, 5),
+            walk_up: UVec2::new(6, 11),
+            walk_left: UVec2::new(12, 17),
+            walk_right: UVec2::new(18, 23),
+        },
     ));
 
     commands.spawn((
@@ -129,28 +152,4 @@ fn spawn_entities(mut commands: Commands, game_assets: Res<GameAssets>) {
         //#[require(StateScoped::<GameState>(GameState::Playing))]
         StateScoped(GameState::Playing),
     ));
-}
-
-// This system loops through all the sprites in the `TextureAtlas`, from  `first_sprite_index` to
-// `last_sprite_index` (both defined in `AnimationConfig`).
-fn execute_animations(time: Res<Time>, mut query: Query<(&mut AnimationConfig, &mut Sprite)>) {
-    for (mut config, mut sprite) in &mut query {
-        // We track how long the current sprite has been displayed for
-        config.frame_timer.tick(time.delta());
-
-        // If it has been displayed for the user-defined amount of time (fps)...
-        if config.frame_timer.just_finished() {
-            if let Some(atlas) = &mut sprite.texture_atlas {
-                if atlas.index == config.last_sprite_index {
-                    // ...and it IS the last frame, then we move back to the first frame and stop.
-                    atlas.index = config.first_sprite_index;
-                } else {
-                    // ...and it is NOT the last frame, then we move to the next frame...
-                    atlas.index += 1;
-                    // ...and reset the frame timer to start counting all over again
-                    config.frame_timer = AnimationConfig::timer_from_fps(config.fps);
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
The PR fixes a couple of issues with the previous implementation.

1. Move the logic of movement + facing direction to it's own system

2. Remove code duplication by returning the range based on the two states:

https://github.com/chungus-studio/bevyning/blob/a7c4abe12bef5d1e9648982c130e707746ce5d2d/src/player.rs#L106-L116

then we only reinsert the sprite once with the new animation config and then we tick/replace the frames at the end